### PR TITLE
feat: fix distructring bug on calling promisify #63

### DIFF
--- a/lessons/lesson1-node-intro.md
+++ b/lessons/lesson1-node-intro.md
@@ -243,7 +243,7 @@ The arguments may be required or optional, but the last argument is required.  T
 
 ```js
 const { promisify } = require("util");
-const fnWithPromise = util.promisify(fnWithCallback);
+const fnWithPromise = promisify(fnWithCallback);
 ```
 
 From an async function, you can now use `async/await`.  If the original function returns an error in the callback, the wrapper does calls `reject(err)` on the promise, which you can catch by calling `fnWithPromise` in a try/catch block.


### PR DESCRIPTION
## PR descripiton
### Fix destructuring:

How I understand, if we’re destructuring promisify from` require("util")`, so we don’t need to reference util again

`const fnWithPromise = promisify(fnWithCallback); `(removed util.)