### PR TITLE
Standardize stretch goal language

### DIFF
--- a/assignments/01-node-intro.md
+++ b/assignments/01-node-intro.md
@@ -109,7 +109,7 @@ That completes the core tasks. Run the core tests with `npm run tdd assignment1a
 
 This part is optional, just like the Advanced section of the lesson. You can skip it and still continue the course, but it is good extra practice.
 
-### Stretch Goal: Streams for Large Files
+### 5. Stretch Goal: Streams for Large Files
 - In your `core-modules-demo.js` script, add streaming:
   - Create a file called `largefile.txt` in your `sample-files` folder. You can do this by writing a loop that writes many lines to the file (e.g., 100 lines of any text). Demonstrate reading `largefile.txt` using a readable stream (`fs.createReadStream`). For each chunk read, log a line that starts with `Read chunk:` (for example, the first 40 characters of the chunk). When the stream ends, log exactly `Finished reading large file with streams.` Use the `highWaterMark` option in `fs.createReadStream` to control the chunk size (e.g., set it to 1024 for 1KB chunks). You can experiment with different values to see how it affects the number of chunks and the output.
 
@@ -123,6 +123,8 @@ Finished reading large file with streams.
 ```
 
 If you complete this optional part, run the advanced tests with `npm run tdd assignment1b`.
+
+---
 
 ## Testing Your Work
 
@@ -142,6 +144,8 @@ npm run tdd assignment1b   # advanced (optional)
 ```
 
 The automated tests will check that your output matches the expected format. If a test fails, check that your console.log statements use the exact spacing and capitalization shown in the examples above.
+
+---
 
 ## Video Submission
 

--- a/assignments/01-node-intro.md
+++ b/assignments/01-node-intro.md
@@ -105,11 +105,11 @@ fs.promises read: Hello from fs.promises!
 
 That completes the core tasks. Run the core tests with `npm run tdd assignment1a`.
 
-## Advanced Tasks (Optional)
+## Stretch Goals (Optional)
 
 This part is optional, just like the Advanced section of the lesson. You can skip it and still continue the course, but it is good extra practice.
 
-### 5. Streams for Large Files
+### Stretch Goal: Streams for Large Files
 - In your `core-modules-demo.js` script, add streaming:
   - Create a file called `largefile.txt` in your `sample-files` folder. You can do this by writing a loop that writes many lines to the file (e.g., 100 lines of any text). Demonstrate reading `largefile.txt` using a readable stream (`fs.createReadStream`). For each chunk read, log a line that starts with `Read chunk:` (for example, the first 40 characters of the chunk). When the stream ends, log exactly `Finished reading large file with streams.` Use the `highWaterMark` option in `fs.createReadStream` to control the chunk size (e.g., set it to 1024 for 1KB chunks). You can experiment with different values to see how it affects the number of chunks and the output.
 

--- a/assignments/02-events-http.md
+++ b/assignments/02-events-http.md
@@ -356,13 +356,15 @@ That completes the core tasks. Run the core tests with:
 npm run tdd assignment2a
 ```
 
-## Advanced Tasks (Optional)
+---
+
+## Stretch Goals (Optional)
 
 This part is optional, just like the Advanced section of the lesson. You can skip it and still continue the course, but it is good extra practice.
 
 The advanced tasks focus on edge cases. An **edge case** is a situation outside the happy path, such as a bad URL, the wrong method, or invalid JSON.
 
-### 6. Raw HTTP Unknown Route
+### 6. Stretch Goal: Raw HTTP Unknown Route
 
 In `assignment2/sampleHTTP.js`, add a response for unknown routes.
 
@@ -386,7 +388,7 @@ Test it in your browser:
 http://localhost:8000/not-here
 ```
 
-### 7. Raw HTTP Invalid JSON
+### 7. Stretch Goal: Raw HTTP Invalid JSON
 
 In `assignment2/sampleHTTP.js`, improve your `POST /echo` route so invalid JSON does not crash the server.
 
@@ -426,7 +428,7 @@ For example:
 
 Your server should return a `400` response instead of crashing.
 
-### 8. Express Unknown Route
+### 8. Stretch Goal: Express Unknown Route
 
 In your root `app.js`, add a final fallback route for unknown Express paths.
 
@@ -450,7 +452,7 @@ http://localhost:3000/unknown
 
 You should get a `404` response.
 
-### 9. Optional Server Lifecycle Polish
+### 9. Stretch Goal: Server Lifecycle Polish
 
 This part is not required for the automated tests, but it is good practice for real server code.
 
@@ -542,6 +544,8 @@ npm run tdd assignment2b   # advanced (optional)
 ```
 
 If a test fails, check file names and route paths first. The tests expect exact names, including `sampleHTTP.js` with uppercase `HTTP`.
+
+---
 
 ## Video Submission
 

--- a/assignments/03-express-middleware.md
+++ b/assignments/03-express-middleware.md
@@ -361,13 +361,15 @@ Run the dog rescue middleware tests:
 npm run tdd assignment3b
 ```
 
-## Advanced Dog Middleware Tasks (Optional)
+---
+
+## Stretch Goals: Advanced Dog Middleware Tasks (Optional)
 
 These tasks are more advanced than the first dog rescue tasks. They are still part of the dog rescue middleware app.
 
 Continue working inside the separate `week-3-middleware` folder.
 
-### 14. Add Security Headers
+### 14. Stretch Goal: Add Security Headers
 
 Add middleware that sets these headers on all responses:
 
@@ -377,7 +379,7 @@ X-Frame-Options: DENY
 X-XSS-Protection: 1; mode=block
 ```
 
-### 15. Add Request Size Limiting
+### 15. Stretch Goal: Add Request Size Limiting
 
 Update JSON parsing to limit body size:
 
@@ -385,7 +387,7 @@ Update JSON parsing to limit body size:
 app.use(express.json({ limit: "1mb" }));
 ```
 
-### 16. Add Content-Type Validation
+### 16. Stretch Goal: Add Content-Type Validation
 
 Add middleware that checks POST requests.
 
@@ -403,7 +405,7 @@ Content-Type must be application/json
 
 `415 Unsupported Media Type` is a more specific HTTP status for unsupported content types, but this assignment and its tests use `400 Bad Request`.
 
-### 17. Add Custom Error Classes
+### 17. Stretch Goal: Add Custom Error Classes
 
 Inside `week-3-middleware`, create:
 
@@ -463,7 +465,7 @@ module.exports = {
 };
 ```
 
-### 18. Use Custom Errors in `routes/dogs.js`
+### Stretch Goal: 18. Use Custom Errors in `routes/dogs.js`
 
 In `week-3-middleware/routes/dogs.js`:
 
@@ -479,7 +481,7 @@ Missing required fields
 not found or not available
 ```
 
-### 19. Improve Advanced Error Handling
+### Stretch Goal: 19. Improve Advanced Error Handling
 
 Update the error handler in `week-3-middleware/app.js`:
 
@@ -520,6 +522,8 @@ Run the advanced dog middleware tests:
 ```bash
 npm run tdd assignment3c
 ```
+
+---
 
 ## Suggested File Structure
 

--- a/assignments/04-tasks-validations.md
+++ b/assignments/04-tasks-validations.md
@@ -587,13 +587,15 @@ node-homework/
     taskSchema.js
 ```
 
-## Advanced Knowledge (Optional)
+---
+
+## Stretch Goals (Optional)
 
 The following ideas give more context. They are useful, but the core tasks above are what you need to complete the assignment.
 
 If you work through this optional advanced section, use `npm run tdd assignment4b` to check the deeper validation, patch update, and password security cases.
 
-### `Object.assign()` and Patch Updates
+### Stretch Goal: `Object.assign()` and Patch Updates
 
 PATCH means partial update.
 
@@ -611,7 +613,7 @@ You do not want to replace the whole task with only that object. You only want t
 
 After using it, still remove `userId` from the response.
 
-### Password Security Details
+### Stretch Goal: Password Security Details
 
 The hashing helpers store a value in this format:
 
@@ -627,7 +629,7 @@ You do not need to memorize these internals. The important rule is to use truste
 
 The same idea applies to other sensitive data. Do not store credit card numbers, government ID numbers, or other private information unless the app truly needs it and you understand the legal and security requirements.
 
-### Validation Boundaries
+### Stretch Goal: Validation Boundaries
 
 Joi validates request data before your app stores it.
 
@@ -635,7 +637,7 @@ Joi does not replace authorization. A task body can be valid and still belong to
 
 Later, database constraints will add another layer of protection.
 
-### Status Code Nuance
+### Stretch Goal: Status Code Nuance
 
 For this assignment:
 
@@ -645,13 +647,15 @@ For this assignment:
 
 Some APIs use `403` when a logged-in user is not allowed to access a resource. This assignment can use `404` for another user's task so the API does not reveal whether that task exists.
 
-### Future Authentication Direction
+### Stretch Goal: Future Authentication Direction
 
 `global.user_id` is only a learning scaffold.
 
 Later, the app should know which client made the request. Common production patterns include sessions, cookies, and tokens.
 
 You do not need to implement those in Assignment 4. The important idea is that the current global login will be replaced later.
+
+---
 
 ## Video Submission
 

--- a/assignments/07-advanced-prisma.md
+++ b/assignments/07-advanced-prisma.md
@@ -105,7 +105,7 @@ const tasks = await prisma.task.findMany({
 - This fetches user information in the same query, eliminating the N+1 problem
 - The test expects tasks to have a `User` property with `name` and `email`
 
-#### b. Optional: Add User Show Method
+#### b. Stretch Goal: Add User Show Method (Optional)
 
 **Note:** This is completely optional and not required. There was no user show method in Assignment 6, and `assignment7.test.js` does not test for it. The test file only imports `logon`, `register`, and `logoff` from `userController` (line 16), and there are no tests that call a user show method. However, if you want to practice eager loading with user-to-task relationships, you can optionally add this method as an extra exercise.
 
@@ -277,9 +277,9 @@ const totalTasks = await prisma.task.count({
 - If `find` is not provided, return all tasks (with pagination)
 - The `contains` operator with `mode: 'insensitive'` translates to `ILIKE '%searchTerm%'` in PostgreSQL
 
-**Optional:** You may also implement additional filters such as `isCompleted`, `priority`, `min_date`, and `max_date` as shown in the lesson materials. The `find` filter is required.
+**Optional Stretch Goal:** You may also implement additional filters such as `isCompleted`, `priority`, `min_date`, and `max_date` as shown in the lesson materials. The `find` filter is required.
 
-#### c. Add Sorting Support (Optional)
+#### c. Stretch Goal: Add Sorting Support (Optional)
 
 The task index endpoint can support sorting by different fields using `sortBy` and `sortDirection` query parameters. This lets users control how their tasks are ordered.
 
@@ -821,7 +821,7 @@ const user = await prisma.user.findUnique({
 });
 ```
 
-#### b. Add Fields Query Parameter Support (Optional)
+#### b. Stretch Goal: Add Fields Query Parameter Support (Optional)
 
 You can enhance endpoints so clients can specify which fields they need. This is optional. If you implement it, parse the fields query parameter and build the select object dynamically.
 

--- a/assignments/09-testing.md
+++ b/assignments/09-testing.md
@@ -433,7 +433,7 @@ Run the tests and make sure all of them pass.
 
 ## **Tests of the User Controller**
 
-Because this assignment is long, the user.controller.test.js file is **optional**. Be sure to implement the actual network operations testing that follows this section. Even if you do not implement the tests in this section, read the descriptions so you understand how they would work.
+Because this assignment is long, the user.controller.test.js file is **an optional stretch goal**. Be sure to implement the actual network operations testing that follows this section. Even if you do not implement the tests in this section, read the descriptions so you understand how they would work.
 
 We want to test logon, but logon sets a cookie. If that cookie is not set, authentication is not working, so we need to test it. The first problem is that a res object returned by `httpMocks.createResponse()` does not keep track of cookies. So we create an enhanced mock response object. This one, created by MockRequestWithCookies, tracks 'Set-Cookie' operations.
 

--- a/assignments/10-deployment.md
+++ b/assignments/10-deployment.md
@@ -82,7 +82,8 @@ Here's the code you'll need to add to the register method, just before userSchem
 
 11. Try testing a register request with Postman. It will fail. Change the request to include the RECAPTCHA_BYPASS in the "X-Recaptcha-Test" header, and it should work.
 
-12. Try `npm run test`. This runs your tests from assignment 9. Some of them will fail. Why? Optional: fix your tests so they complete correctly by adding the header you need.
+12. Try `npm run test`. This runs your tests from assignment 9. Some of them will fail. Why?
+Optional Stretch Goal: fix your tests so they complete correctly by adding the header you need.
 
 You have now run the TDD for this assignment and the Postman test. These are not complete tests of reCAPTCHA because they use the bypass instead of a real token. You will correct that in the next lesson.
 


### PR DESCRIPTION
Update any mentions of optional/advanced tasks to include "stretch goal" language. This ensures the text is consistent with the AI reviewer's prompts and hopefully reduces instances where AirHub mistakes an optional goal for a required one. 